### PR TITLE
Inflation-Bug-Compensation

### DIFF
--- a/Inflation-Bug-Compensation.md
+++ b/Inflation-Bug-Compensation.md
@@ -1,0 +1,47 @@
+---
+layout: fr
+network_vote: yes
+title: Inflation-Bug-Compensation
+author: kangoala
+date: March 06, 2021
+amount: 500000
+milestones:
+  - name: hacker makes initial payment (5%)
+    funds: 25000
+    done:
+    status: unfinished
+  - name: particl community vote (> 80%)
+    funds: 0
+    done:
+    status: unfinished
+  - name: hacker pays outstanding (95%)
+    funds: 475000
+    done:
+    status: unfinished
+payouts:
+  - date:
+    amount:
+  - date:
+    amount:
+  - date:
+    amount:
+---
+Since up until Particl Core 0.19.2.3, a hacker took profit of the now released vulnerability, many community members feel deceived and expect compensation for their diluted PART holdings. Investigations are on the way to gather personal information on the hackers identity.
+
+I think both parties, the hacker as well as the particl community, should rule off this matter and do a restart without any accusations.
+
+In this proposal I'd like to ask (maybe in a kind of naive way), the hacker to fund the following CCS with a significant amount of either BTC, XMR or PART Coins and thus supporting, in a sign of good will, the future development of the particl project. As equivalent the community should guaranty and prove by an positive vote with more than 80% of all participants to abstain from any further investigations to gain personal information on the hackers identity. Also, even if any personal information would be known, the particl community would clearly resign of any request for payback or to take vengeance in any form. The hackers behaviour will be rather seen as a medicative way to a further improve the Particl project. However, therefore the hacker would have to show his willingness to share a significant part of his personal gains with the particl community, by funding this CCS Proposal.
+
+The Proposal is as follows:
+
+The hacker will fund the Particl Project by transfering either 
+	10 BTC or,
+	2500 XMR or,
+	500000 PART
+
+to the provided addresses in this CCS Proposal (addresses to be provided by the particl team).
+
+As a sign of his willingness he first has to transfer 5 % of the amount to the corresponding CCS address.
+In a second step, the particl community will vote to resign from any form of vengeance or further compensation. If this vote passed successfully with more than 80% acceptance, the hacker would have to transfer the outstanding 95%. If the vote doesn't pass the 80%, the paied amount of 5% will be transfered back to the hackers account (if any account is given or provided).
+
+There's a certain time frame this CCS will be valid. I suggest to give the hacker up until April 30th 2021 the possibility to reply on this CCS Proposal by making an initial payment of 5% of either given currency. As long as no initial payment has been done, also no further action will be required by the community. 


### PR DESCRIPTION
Since up until Particl Core 0.19.2.3, a hacker took profit of the now released vulnerability, many community members feel deceived and expect compensation for their diluted PART holdings. Investigations are on the way to gather personal information on the hackers identity.

I think both parties, the hacker as well as the particl community, should rule off this matter and do a restart without any accusations.

In this proposal I'd like to ask (maybe in a kind of naive way), the hacker to fund the following CCS with a significant amount of either BTC, XMR or PART Coins and thus supporting, in a sign of good will, the future development of the particl project. As equivalent the community should guaranty and prove by an positive vote with more than 80% of all participants to abstain from any further investigations to gain personal information on the hackers identity. Also, even if any personal information would be known, the particl community would clearly resign of any request for payback or to take vengeance in any form. The hackers behaviour will be rather seen as a medicative way to a further improve the Particl project. However, therefore the hacker would have to show his willingness to share a significant part of his personal gains with the particl community, by funding this CCS Proposal.

The Proposal is as follows:

The hacker will fund the Particl Project by transfering either 
	10 BTC or,
	2500 XMR or,
	500000 PART

to the provided addresses in this CCS Proposal (addresses to be provided by the particl team).

As a sign of his willingness he first has to transfer 5 % of the amount to the corresponding CCS address.
In a second step, the particl community will vote to resign from any form of vengeance or further compensation. If this vote passed successfully with more than 80% acceptance, the hacker would have to transfer the outstanding 95%. If the vote doesn't pass the 80%, the paied amount of 5% will be transfered back to the hackers account (if any account is given or provided).

There's a certain time frame this CCS will be valid. I suggest to give the hacker up until April 30th 2021 the possibility to reply on this CCS Proposal by making an initial payment of 5% of either given currency. As long as no initial payment has been done, also no further action will be required by the community. 
