### PR TITLE
Advertising-Proposal

### DIFF
--- a/Advertising-Proposal
+++ b/Advertising-Proposal
@@ -1,0 +1,46 @@
+---
+layout: fr
+network_vote: no
+title: Advertising Proposal
+author: particlmike33
+date: May 5, 2022
+amount: 100,000
+milestones:
+  - name: Coinmarketcap ads
+    funds: 50,000
+    done:
+    status: unfinished
+  - name: Coingecko ads + youtube sponsorships
+    funds: 50,000
+    done:
+    status: unfinished
+payouts:
+  - date:
+    amount:
+  - date:
+    amount:
+---
+
+Particl will have its 3.2 release soon, which means the marketplace will be near perfect.  There will be infinite markets/shops and
+public/private messaging between sellers and buyers.
+
+Particl should be one of the top projects out there, but no one knows about us.  This can be solved with advertising.
+
+In addition, advertising should help increase our liquidity which will be good for our devs, since currently they are paid in part yet it is very
+hard for them to sell.  We don't want this project to die, so I think it's paramount we advertise once 3.2 is released.
+
+Coinmarketcap.com offers great advertising opportunities.  We can be sponsored in their newsletter, and/or appear in their trending coins section!
+
+This would give us massive visibility.
+
+Coingecko and reddit also both offer traditional banner ads, which could be helpful for us.
+
+I have also reached out to BitBoy and CoinBureau on youtube (they each have a couple million subscribers) to see if they would let us sponsor a video.
+
+The milestones and amounts I put in this proposal are pretty voluntary, it depends on where people want to advertise and how much they want to allocate
+to each ad.  I just wanted to get the ball rolling by starting this proposal and discussing it in discord as well.
+
+The funds to pay for advertising can come from the 138,000 part we have in reserve that are leftover from the first dev funding proposal.
+The devs are currently funded through the second funding proposal, so the 138,000 left over from the first, should be okay for us to use.
+
+Everyone please let me know what you think!


### PR DESCRIPTION
Particl will have its 3.2 release soon, which means the marketplace will be near perfect.  There will be infinite markets/shops and
public/private messaging between sellers and buyers.

Particl should be one of the top projects out there, but no one knows about us.  This can be solved with advertising.

In addition, advertising should help increase our liquidity which will be good for our devs, since currently they are paid in part yet it is very
hard for them to sell.  We don't want this project to die, so I think it's paramount we advertise once 3.2 is released.

Coinmarketcap.com offers great advertising opportunities.  We can be sponsored in their newsletter, and/or appear in their trending coins section!

This would give us massive visibility.

Coingecko and reddit also both offer traditional banner ads, which could be helpful for us.

I have also reached out to BitBoy and CoinBureau on youtube (they each have a couple million subscribers) to see if they would let us sponsor a video.

The milestones and amounts I put in this proposal are pretty voluntary, it depends on where people want to advertise and how much they want to allocate
to each ad.  I just wanted to get the ball rolling by starting this proposal and discussing it in discord as well.

The funds to pay for advertising can come from the 138,000 part we have in reserve that are leftover from the first dev funding proposal.
The devs are currently funded through the second funding proposal, so the 138,000 left over from the first, should be okay for us to use.

Everyone please let me know what you think!