### PR TITLE
Advertising-Proposal

### DIFF
--- a/Advertising-Proposal.md
+++ b/Advertising-Proposal.md
@@ -1,0 +1,54 @@
+---
+layout: fr
+network_vote: no
+title: Advertising-Proposal
+author: particlmike33
+date: May 10, 2022
+amount: 46000
+milestones:
+  - name: Complete Advertising Plan
+    funds: 46000
+    done:
+    status: unfinished
+  - name: Finish Advertising
+    funds: 0
+    done:
+    status: unfinished
+payouts:
+  - date:
+    amount:
+  - date:
+    amount:
+---
+
+Particl badly needs advertising.  We are an amazing project with a working DAPP (the marketplace), yet no one knows about us, and our liquidity is nonexistant.
+
+This makes it difficult for the devs to sell the funds they receive from the treasury.  If we go on like this much longer, we may just die out.
+
+The marketplace is finished, and it is the perfect time to advertise it (along with the fact we are planning a DEX to go with the marketplace).
+
+There is about 46,000 part in the treasury, that is up to the community how to spend.
+
+In addition, there is 138,000 part in the reserve fund that is not needed at the moment.  It is leftover from the first dev funding proposal,
+and they currently have the second funding proposal keeping them going.
+
+It is up to the devs what the 138,000 part will be used for.
+
+I am asking simultaneously for the community to approve the 46,000 part in the treasury to be used for advertising, and for the devs to approve
+the 138,000 (or a chunk of them) to be also approved for advertising.
+
+I've researched many advertising options, and the ones that seem best to me are:
+
+1) Appearing in coinmarketcap's trending section.  This costs $1 CPC (per click)
+2) Appearing in coinmarketcap's newsletter.  This is expensive:  $6k for a day, $20k for a week, $50k for a month.
+3) Having a sponsored video by youtuber DataDash (500k subscribers and consistently 50k views/video).  This costs $4-15k depending on the length of the
+   sponsored section for us
+4) Having a dedicated channel in Max Maher's discord.  This costs $2500
+5) Using chainwire.org, which guarentees a news release that we write gets featured in tons of online crypto publications.  This costs $1.5-9k depending
+   on how many places we want to be featured.
+6) Using the PR firm Market Across, which has led PR campaigns for projects such as: Binance, Polkadot, Huobi, TRON, Polygon(Matic), Tezos, Crypto.com, eToro,
+   Consensys, Bybit, Cardano, NEO, and Qtum.  The price of this varies greatly from a one time payment of $100, to a monthly recurring payment of $20k
+   
+   
+Many of these companies sent me case studies and pdfs of more information, but I wanted to keep this CCS proposal short and sweet.  If anyone is interested in
+a certain option listed here, I can post in the comment section what the company has sent me, so you can read more in depth.


### PR DESCRIPTION
Particl badly needs advertising.  We are an amazing project with a working DAPP (the marketplace), yet no one knows about us, and our liquidity is nearly zero.

The devs are already having trouble selling their 35k part they receive every month from the treasury.  If the situation gets any worse, they will be unable to raise any funds.  And the devs deserve to get paid for their work!  If our liquidity drops any lower than it is now, it means our project will be dead because the devs won't be getting paid.  This is a serious issue.

The perfect time to advertise is now.  We have a decentralized marketplace with infinite markets, MAD escrow, and private encrypted messaging.  And we have a DEX in the works.

Waiting to advertise until the DEX is completed would be a mistake.  We would be gambling our projects survival on if liquidity doesn't drop any lower anytime soon.  That is a gamble I'm not willing to take.  We need advertising ASAP to ensure our devs keep getting paid.

Newcomers that hear about us through advertising will be perfectly okay with buying part on a centralized exchange like bittrex or probit.  99% of all crypto projects out there rely on CEXs and don't have a DEX.  CEXs are widely used.  I'm not saying a DEX wouldn't be amazing for us--it is an amazing feature thanks to our devs.  But it isn't needed before marketing.  Newcomers can buy part on a CEX like they do for every other project out there.  A DEX is a great feature to have once we have more people, it isn't a necessity to have before we get new people.

In terms of funding for advertising, there is about 46,000 part in the treasury, that is up to the community how to spend.

In addition, there is 138,000 part in the reserve fund that is not needed at the moment.  It is leftover from the first dev funding proposal, and they currently have the second funding proposal keeping them going.

It is up to the devs what the 138,000 part will be used for.

I am asking simultaneously for the community to approve the 46,000 part in the treasury to be used for advertising, and for the devs to approve the 138,000 (or a chunk of them) to be also approved for advertising.

I've researched many advertising options, and the ones that seem best to me are:

Milestone 1: Pay coinmarketcap $10k for us to be in the trending section. This will keep us trending until we have had 10k clicks, it is $1 CPC.  Coinmarketcap has 700 million monthly page views.  Imagine 10k people going to Particl's site and many more seeing us in Coinmarketcap's trending section in the search bar!

Milestone 2: Pay MarketAcross $20k for them doing a month of work. What $20k gets us is written out here: https://drive.google.com/file/d/1--0lnkyiY-s6Biudb7nSrJa3dLeCJn01/view Milestone 2 should happen concurrently with Milestone 1 for maximum affect

Milestone 3: Pay youtuber DataDash (500k subscribers and 50k views/video) for a review/interview about Particl. This costs $15k. Maybe a dev or a well known community member can be a part of the video?!

All Milestones happen at the same time for maximum affect.

Total Cost: 45k, there is about 46k particl in the treasury, and another 138k in reserves. The community can vote on the treasury funds, it is up to the devs if they want to contribute some of the reserve funds.  I'm assuming at this point we only have the 46k from the treasury, if the devs say otherwise, we will add on additional milestones.

If people are uncomfortable with giving me the funds (which I understand) then hopefully the devs can get involved. I can do all the work and plan all the discussions with the 3 advertising companies listed above, and when the PR is ready just forward the invoice to the devs and they can pay the companies. They don't need to do any of the work/planning if they don't want to, just pay the invoices.  This way money isn't sent straight to me if that makes the community uncomfortable.

MarketAcross's $20k plan is the following:

Deliverables:

--Monthly PR & Content marketing campaign

--Messaging Brief. On-going Adjustments & strategy

--At least 13 unique articles and media coverage

--2 Reddit Promotions Or Telegram AMAs/Podcasts

--Positioning and messaging strategy - Taking a deep dive into your solution and assembling a detailed
    brief on what angles we believe should be pushed to which media.
    
--Advisory - Provide our experienced inputs on on-going matters, whether PR or marketing relevant.
  
--Press releases - Strategizing, drafting, and distributing news announcements you have with a guarantee
    for a minimum amount of hits.
    
--Media outreach - Identifying relevant publications for each news announcement and actively pitching
    reporters in attempt to secure maximum and optimal coverage.
    
--Content marketing - Utilizing our network to communicate educational content and third-party coverage
    according to the agreed upon market positioning and messaging strategy, this could include:
    
--Generating Link building value from powerful domains to keywords you would like to push.
    
--Expert commentary - Positioning your C-level executives as experts by commenting on viral stories or
    topics aligned with our overall strategy.
   
--Moderation and reports - Biweekly reporting and/or calls on-demand, monthly reports of coverage we
    secured.
    
--Social amplification - Amplifying the media hits on Reddit to create virality. Getting more eyeballs and
    amplifying our top articles through our vast reddit network - we guarantee to upvote to at least top 5 on
    any top subreddit we would choose to go for. On the 4Chan front (in specific cases), we would be pushing
    daily threads to make sure we control and shape up the narratives we are pushing alongside our media
    outreach efforts.
    
--AMAs and podcasts - We will work to connect with influencers in Finance/Crypto and in order to generate
    coverage to your brand as well as to highlight your executive team. This will be achieved primarily via
    podcasts and YouTube channel coverage pieces, as well as setting up AMAs on telegram.

--Designated account manager.
