### PR TITLE
Inflation Treasury Adjustments

### DIFF
--- a/inflation-treasury-adjustments.md
+++ b/inflation-treasury-adjustments.md
@@ -2,8 +2,8 @@
 layout: fr
 network_vote: yes
 network_vote_id: 25
-network_vote_block_height_start: 
-network_vote_block_height_end: 
+network_vote_block_height_start: 2010550
+network_vote_block_height_end: 2020630
 consensus_vote: yes
 title: Network Treasury and Inflation Adjustments
 author: Dr. Kapil Amarasinghe

--- a/inflation-treasury-adjustments.md
+++ b/inflation-treasury-adjustments.md
@@ -1,5 +1,5 @@
 ---
-layout: cp
+layout: fr
 network_vote: yes
 network_vote_id: 25
 network_vote_block_height_start: 

--- a/inflation-treasury-adjustments.md
+++ b/inflation-treasury-adjustments.md
@@ -48,4 +48,4 @@ The rationale behind this proposal is to transition Particl's $PART token toward
 
 # Full Proposal
 
-To read Dr. Kapil Amarasinghe's proposal in full, navigate to this blog post on Particl News: https://particl.news/disable-treasury-inflation-adjustment
+To read Dr. Kapil Amarasinghe's proposal in full, navigate to this blog post on Particl News: https://particl.news/ccs-proposal-disable-treasury-rewards-and-reduce-emission-rate/

--- a/inflation-treasury-adjustments.md
+++ b/inflation-treasury-adjustments.md
@@ -7,13 +7,13 @@ network_vote_block_height_end:
 consensus_vote: yes
 title: Network Treasury and Inflation Adjustments
 author: Dr. Kapil Amarasinghe
-date: May 21, 2025
+date: June 10, 2025
 amount: 1 PART
 milestones:
   - name: Disable network rewards going to community treasury and reduce inflation rate
     funds: 100% (1 PART)
     done:
-    status: finished
+    status: unfinished
 payouts:
   - date:
     amount:

--- a/inflation-treasury-adjustments.md
+++ b/inflation-treasury-adjustments.md
@@ -1,0 +1,51 @@
+---
+layout: cp
+network_vote: yes
+network_vote_id: 25
+network_vote_block_height_start: 
+network_vote_block_height_end: 
+consensus_vote: yes
+title: Network Treasury and Inflation Adjustments
+author: Dr. Kapil Amarasinghe
+date: May 21, 2025
+amount: 1 PART
+milestones:
+  - name: Disable network rewards going to community treasury and reduce inflation rate
+    funds: 100% (1 PART)
+    done:
+    status: finished
+payouts:
+  - date:
+    amount:
+---
+
+# Summary
+
+This proposal outlines a plan for a hard fork of the Particl Blockchain to eliminate the decentralized treasury model, immediately reduce the annual inflation rate from 7% to 3.5%, and then incrementally decrease it by 0.5% per year until it reaches 1.0% by June 2031.
+
+# Rationale
+
+The rationale behind this proposal is to transition Particl's $PART token towards becoming "hard money" by addressing issues with its current economic model.
+
+## Scrapping the Decentralized Treasury
+
+* The treasury model, while initially funding development, eventually contributed to a "death spiral" in $PART's liquidity due to developers needing to sell $PART to cover expenses, thus creating constant sell pressure.
+* The declining value of $PART made the treasury insufficient for funding development, leading to reliance on community donations and development delays.
+* The treasury model, which currently directs 50% of the block reward to a fund, raises concerns about structural centralization, despite community voting on fund allocation.
+* The proposal suggests replacing the treasury with a voluntary, multi-currency donation system, which is generally seen by the wider cryptocurrency community as more decentralized, supportive of user consent, and protective against single-currency liquidity shocks, as evidenced by the recently successful BasicSwap Monero CCS proposal.
+
+## Lowering Inflation
+
+* The current 7% annual inflation rate is too high, devaluing $PART more than traditional fiat currencies and making it "soft money". The goal is to transform $PART into "hard money," with 0% inflation or being structurally deflationary.
+* Proof-of-stake systems with high inflation and insufficient distribution trend towards supply centralization and a liquidity doom loop, as falling prices lead to accumulation by a shrinking pool of stakers, further killing liquidity. This is unappealing to privacy-conscious users who oppose centralization.
+* By reducing inflation, initially to 3.5% and then gradually to 1.0%, the proposal aims to make $PART a more stable store of value. This puts pressure on the community and developers to increase network adoption and transaction fee revenue (from BasicSwapDex and Particl Marketplace) to sustain staking rewards, rather than relying on new token issuance.
+* Similar parallels can be drawn with the problems of inflationary fiat currencies ("soft money"), which devalue savings, disproportionately affect ordinary people, and lead to wealth centralization. This proposal contributes to $PART avoiding these pitfalls.
+* Even at 1.0% inflation, $PART would be harder money than most cryptocurrencies and traditional currencies. The ultimate hope is to achieve 0% inflation, with network security funded entirely by transaction fees.
+
+# Timeframe and Voting Requirements
+
+**Because this proposal requires a protocol consensus vote (major change in the protocol), its voting phase will last for 10,080 blocks, require a quorum of at least 20% of the supply, and obtain at least 75% of the votes in favor of the proposal.**
+
+# Full Proposal
+
+To read Dr. Kapil Amarasinghe's proposal in full, navigate to this blog post on Particl News: https://particl.news/disable-treasury-inflation-adjustment

--- a/inflation-treasury-adjustments.md
+++ b/inflation-treasury-adjustments.md
@@ -4,7 +4,6 @@ network_vote: yes
 network_vote_id: 25
 network_vote_block_height_start: 2010550
 network_vote_block_height_end: 2020630
-consensus_vote: yes
 title: Network Treasury and Inflation Adjustments
 author: Dr. Kapil Amarasinghe
 date: June 10, 2025


### PR DESCRIPTION
# Summary

This proposal outlines a plan for a hard fork of the Particl Blockchain to eliminate the decentralized treasury model, immediately reduce the annual inflation rate from 7% to 3.5%, and then incrementally decrease it by 0.5% per year until it reaches 1.0% by June 2031.

# Rationale

The rationale behind this proposal is to transition Particl's $PART token towards becoming "hard money" by addressing issues with its current economic model.

## Scrapping the Decentralized Treasury

* The treasury model, while initially funding development, eventually contributed to a "death spiral" in $PART's liquidity due to developers needing to sell $PART to cover expenses, thus creating constant sell pressure.
* The declining value of $PART made the treasury insufficient for funding development, leading to reliance on community donations and development delays.
* The treasury model, which currently directs 50% of the block reward to a fund, raises concerns about structural centralization, despite community voting on fund allocation.
* The proposal suggests replacing the treasury with a voluntary, multi-currency donation system, which is generally seen by the wider cryptocurrency community as more decentralized, supportive of user consent, and protective against single-currency liquidity shocks, as evidenced by the recently successful BasicSwap Monero CCS proposal.

## Lowering Inflation

* The current 7% annual inflation rate is too high, devaluing $PART more than traditional fiat currencies and making it "soft money". The goal is to transform $PART into "hard money," with 0% inflation or being structurally deflationary.
* Proof-of-stake systems with high inflation and insufficient distribution trend towards supply centralization and a liquidity doom loop, as falling prices lead to accumulation by a shrinking pool of stakers, further killing liquidity. This is unappealing to privacy-conscious users who oppose centralization.
* By reducing inflation, initially to 3.5% and then gradually to 1.0%, the proposal aims to make $PART a more stable store of value. This puts pressure on the community and developers to increase network adoption and transaction fee revenue (from BasicSwapDex and Particl Marketplace) to sustain staking rewards, rather than relying on new token issuance.
* Similar parallels can be drawn with the problems of inflationary fiat currencies ("soft money"), which devalue savings, disproportionately affect ordinary people, and lead to wealth centralization. This proposal contributes to $PART avoiding these pitfalls.
* Even at 1.0% inflation, $PART would be harder money than most cryptocurrencies and traditional currencies. The ultimate hope is to achieve 0% inflation, with network security funded entirely by transaction fees.

# Timeframe and Voting Requirements

**Because this proposal requires a protocol consensus vote (major change in the protocol), its voting phase will last for 10,080 blocks, require a quorum of at least 20% of the supply, and obtain at least 75% of the votes in favor of the proposal.**

# Full Proposal

To read Dr. Kapil Amarasinghe's proposal in full, navigate to this blog post on Particl News: https://particl.news/disable-treasury-inflation-adjustment